### PR TITLE
Switch printing to be dictionary-based substitution

### DIFF
--- a/freq.py
+++ b/freq.py
@@ -8,6 +8,16 @@ length = len(alphabet)
 alphabet_count = [['',0]]*length
 starts_with_count = [['',0]]*length
 
+replacements = {}
+
+def replaceFromDict(cipher, replacements):
+    res = cipher
+    for (rep, val) in replacements.items():
+        res = res.replace(rep, val)
+    
+    return res
+
+
 for i in range(length):
     alphabet_count[i] = [alphabet[i],0]
     starts_with_count[i] = [alphabet[i],0]

--- a/freq.py
+++ b/freq.py
@@ -37,30 +37,34 @@ sorted_alphabet.sort(reverse=1,key=second_value)
 for i in range(length):
     sorted_alphabet[i][1]=round(sorted_alphabet[i][1]/cipher_length*100,2)
 
-current_text = text
 x=''
 print("Current Ciphertext:")
-print(current_text)
-current_alphabet = alphabet
+print(text)
 
 while(x!='X'):
-    x= input("\nPress A to display current alphabet, F to display frequencies, C to display current ciphertext, R to replace a letter, or X to exit: ").upper()
+    x= input("\nPress A to display current alphabet, F to display frequencies, C to display current ciphertext, R to replace a letter, U to reset the alphabet, or X to exit: ").upper()
     if x=='A':
-        print(current_alphabet)
-    if x=='F':
+        print(alphabet)
+        print(replaceFromDict(alphabet, replacements))
+    elif x=='F':
         print(sorted_alphabet)
     elif x=='C':
-        print(current_text)
+        print(replaceFromDict(text, replacements))
     elif x=='R':
         old_letter = input("Old letter: ").upper()
         new_letter = input("New letter: ").lower()
-        current_text = current_text.replace(old_letter,new_letter)
-        current_alphabet = current_alphabet.replace(old_letter,new_letter)
-        print("\nUpdated Ciphertext:")
-        print(current_text)        
-        print("\nUpdated Alphabet:")
-        print(alphabet+" ->")
-        print(current_alphabet)
-        
+        if len(old_letter) != len(new_letter):
+            print("Length of old and new do not match!")
+        else:
+            for l in range(len(old_letter)):
+                replacements[old_letter[l]] = new_letter[l]
+            print("\nUpdated Ciphertext:")
+            print(replaceFromDict(text, replacements))        
+            print("\nUpdated Alphabet:")
+            print(alphabet+" ->")
+            print(replaceFromDict(alphabet, replacements))
+    elif x=='U':
+        replacements = {}
+        print("Alphabet reset!")    
     elif x!='X':
         print("Erm what the deuce")


### PR DESCRIPTION
Changes:
- Adds `replaceWithDict()` function that takes a string and prints out a substituted version based on a dictionary, with the format `{'C':'p', 'D':'q', ...}` where `'C'` is the cipher character and `'p'` is the plaintext character it maps to. This allows the rollback of a substituted character if it's found to be wrong without a full restart. You can also change what a ciphertext character is replaced with/
- Add ability to pass multiple characters to the `R` command option at a time, so that you can pass 
  ```
  Press A to display current alphabet, F to display frequencies, C to display current ciphertext, R to replace a letter, U to reset the alphabet, or X to exit: R

  Old letter: CAT
  New letter: dog
  ```
  This will map `C` to `d`, `A` to `o`, and `T` to `g`. The program will inform the user if the two inputs are of differing lengths and not make any changes in that case. Single-letter replacements still work.
- Add `U` option to reset the replacements dictionary and begin from scratch. Clears the dictionary.
